### PR TITLE
1.0.0b

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,33 @@ sudo usermod -aG docker yourusername
 docker compose up -d
 ```
 
+## How to add new application to dev environment
+1. Place files for application into installed package `www` directory
+2. Choose local domain for application and add it to hosts configuration (eg. `/etc/hosts` on Ubuntu or `C:\Windows\System32\drivers\etc\hosts` on Windows)
+    ```
+    ## EXAMPLE FOR http://example.local ##
+   127.0.0.1       example.local www.example.local
+   ```
+3. Create nginx config for application in the `conf/nginx` package folder (check `cong/nginx/example.conf` for details)
+   1. specify the root folder using path inside of container. For example if your have application in `www/example` then `root /var/www/example;` should be specified in config
+   2. configure required version of PHP for FastCGI server (`fastcgi_pass`) using container name and default PHP port.
+   For example for PHP 8.1 this will be `fastcgi_pass php81:9000`. You can use `upstream` config for this purpose, for example:
+   ```
+   upstream fastcgi_backend_exmp {
+       server  php82:9000;
+   }
+   ....
+       location ~ ^/.+\.php(/|$) {
+           fastcgi_pass   fastcgi_backend_exmp;
+           ....
+   ```
+4. Restart nginx container and application should be accessible using previously defined local domain
+   ```
+   docker container restart nginx
+   ```
+
 ## TODO List
-- prepare detailed documentation and description
-- test prepared images and compose configuration
+- prepare more detailed documentation and description (_80% done_)
+- test prepared images and compose configuration (_70% done_)
 - include additional services/images in package
-- create SH script for automatic deployment and configuration
+- ~~create SH script for automatic deployment and configuration~~ (_deprecated as not needed for dev env_)

--- a/VERSION
+++ b/VERSION
@@ -1,0 +1,7 @@
+1.0.0b
+Initial beta release
+- release includes main configuration for Adobe Commerce 2.4 stack with PHP 7.4, 8.1 and 8.2 on board
+- release includes elasticsearch 7 and opensearch as well
+- some minor compose config fixes added compare to initial code
+- additional information specified in package doc
+------------------------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,7 @@ services:
     # build: ./images/php/7.4
     volumes:
       - ./www/:/var/www/
-      - ./www/composer:/home/apache/.composer
-      - ~/.ssh/:/home/apache/.ssh/
+      - ~/.ssh/:/var/www/.ssh/
     hostname: php74.ivanko.dockerl
     container_name: php74
     extra_hosts:
@@ -24,8 +23,7 @@ services:
     # build: ./images/php/8.1
     volumes:
       - ./www/:/var/www/
-      - ./www/composer:/home/apache/.composer
-      - ~/.ssh/:/home/app/.ssh/
+      - ~/.ssh/:/var/www/.ssh/
     hostname: php81.ivanko.docker
     container_name: php81
     extra_hosts:
@@ -43,8 +41,7 @@ services:
     # build: ./images/php/8.2
     volumes:
       - ./www/:/var/www/
-      - ./www/composer:/home/apache/.composer
-      - ~/.ssh/:/home/app/.ssh/
+      - ~/.ssh/:/var/www/.ssh/
     hostname: php82.ivanko.docker
     container_name: php82
     extra_hosts:


### PR DESCRIPTION
- release includes main configuration for Adobe Commerce 2.4 stack with PHP 7.4, 8.1 and 8.2 on board
- release includes elasticsearch 7 and opensearch as well
- some minor compose config fixes added compare to initial code
- additional information specified in package doc